### PR TITLE
added meteor-bootboxjs as a package

### DIFF
--- a/smart.json
+++ b/smart.json
@@ -6,5 +6,6 @@
 	"version": "0.1.6",
 	"git": "https://github.com/jzgoda/managedUsers.git",
 	"packages": {
+		"bootboxjs": {}
 	}
 }


### PR DESCRIPTION
What do you think about using this https://github.com/alisalaah/meteor-bootbox as a direct dependency and getting rid of that "external" dependency in the description? :)
