### PR TITLE
Fix tests for 0.6.5.

### DIFF
--- a/package.js
+++ b/package.js
@@ -10,6 +10,6 @@ Package.on_use(function(api) {
 });
 
 Package.on_test(function(api) {
-	api.use(['managedUsers', 'tinytest', 'test-helpers'], ['client', 'server']);
+	api.use(['managedUsers', 'tinytest', 'test-helpers', 'accounts-password'], ['client', 'server']);
 	api.add_files('managedUsers_tests.js', ['client', 'server']);
 });


### PR DESCRIPTION
The package.js on_test needs to include "accounts-password" for the
tests to see "Accounts".

(Running tests displays "Uncaught ReferenceError: Accounts is not defined" in the browser console).
