### PR TITLE
Allow permissions to be checked from Meteor publish functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Meteor.ManagedUsers.availablePermissions = function() {
 
 Testing for Permissions
 ------------------------
-` Meteor.ManagedUsers.hasPermission(permissionName) ` accepts a string of the permission's name, and then returns a boolean if the current user has that permission.
+` Meteor.ManagedUsers.hasPermission(permissionName [, userId]) ` accepts a string of the permission's name, and then returns a boolean if the user (defaulting to the current user) has that permission.
 
 
 To Do

--- a/managedUsers.js
+++ b/managedUsers.js
@@ -5,9 +5,19 @@ Meteor.ManagedUsers = {
 		return {};
 	},
 
+	user: function(userId) {
+		if (userId === undefined)
+			return Meteor.user();
+		else if (typeof userId === "string")
+			return Meteor.users.findOne(userId);
+		else
+			return null;
+	},
+
 	// Input Validation
-	isAdmin: function() {
-		return (Meteor.user() &&  (Meteor.user().username === "admin"));
+	isAdmin: function(userId) {
+		var user = Meteor.ManagedUsers.user(userId);
+		return (user && user.username === "admin");
 	},
 
 	checkUsername: function(username, userId) {
@@ -32,9 +42,12 @@ Meteor.ManagedUsers = {
 		}
 	},
 
-	hasPermission: function(permission) {
-		if(Meteor.user() && ((Meteor.user().username === "admin") || (Meteor.user().permissions && Meteor.user().permissions[permission] == true)))
-			return true;
+	hasPermission: function(permission, userId) {
+		var user = Meteor.ManagedUsers.user(userId);
+		return (user &&
+						(user.username === "admin" ||
+						 (user.permissions && user.permissions[permission] == true))
+					 );
 	}
 }
 

--- a/managedUsers_tests.js
+++ b/managedUsers_tests.js
@@ -44,6 +44,7 @@ if(Meteor.isClient) {
 		logoutStep,
 		function(test, expect) {
 			test.isFalse(Meteor.ManagedUsers.isAdmin());
+			test.isFalse(Meteor.ManagedUsers.isAdmin(Meteor.userId()));
 
 			Accounts.createUser({username: "someone", password: "abc123", profile: {name: "Some One"}}, function(error) {
 				test.equal(error.reason, "Signups forbidden");
@@ -62,6 +63,7 @@ if(Meteor.isClient) {
 				test.equal(error, undefined);
 				test.equal(Meteor.user().username, "admin");
 				test.isTrue(Meteor.ManagedUsers.isAdmin());
+				test.isTrue(Meteor.ManagedUsers.isAdmin(Meteor.userId()));
 			}));
 		},
 

--- a/package.js
+++ b/package.js
@@ -10,6 +10,6 @@ Package.on_use(function(api) {
 });
 
 Package.on_test(function(api) {
-	api.use(['managedUsers', 'tinytest', 'test-helpers'], ['client', 'server']);
+	api.use(['managedUsers', 'tinytest', 'test-helpers', 'accounts-password'], ['client', 'server']);
 	api.add_files('managedUsers_tests.js', ['client', 'server']);
 });


### PR DESCRIPTION
Meteor.user() and Meteor.userId() can't be called from Meteor.publish
functions.  This commit adds an optional `userId` argument to `isAdmin`
and `hasPermission`, allowing permissions to be checked from publish
functions.
